### PR TITLE
Style fix as requested

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,26 +28,25 @@ appAPI.ready(function ($) {
   .append('<h3>Dev dependencies', $devDepsList)
   .appendTo('.repository-content');
 
-  function applyStyles () {
-    $('.deps').css({
-      listStyle: 'none',
-      padding: 0
-    })
+  $('<style>').appendTo('head').html(
+    '.deps {' +
+      'list-style: none;' +
+      'padding: 0 !important;' +
+    '}' +
 
-    $('.deps > li').css({
-      padding: '10px',
-      borderBottom: '1px solid #DDD'
-    })
+    '.deps > li {' +
+      'padding: 10px;' +
+      'border-bottom: 1px solid #DDD;' +
+    '}' +
 
-    $('.deps > li:last-child').css({
-      borderBottom: 'none'
-    })
+    '.deps > li:last-child {' +
+      'border-bottom: none;' +
+    '}' +
 
-    $('li.empty').css({
-      opacity: '0.6'
-    })
-
-  }
+    'li.empty {' +
+      'opacity: 0.6;' +
+    '}'
+  );
 
   appAPI.request.get(pkgUrl, function (data) {
     var pkg = JSON.parse(data)
@@ -57,7 +56,6 @@ appAPI.ready(function ($) {
 
     if (pkg.dependencies === undefined) {
       $depsList.append("<li class='empty'>None found in package.json</li>")
-      applyStyles()
     } else {
       var depNames = Object.keys(pkg.dependencies)
 
@@ -74,7 +72,6 @@ appAPI.ready(function ($) {
           if (dep.repository && dep.repository.url) {
             $('#dep-' + dep.name).append(" <a href='" + dep.repository.url + "'>(repo)</a>")
           }
-          applyStyles()
         })
       }
     }
@@ -85,7 +82,6 @@ appAPI.ready(function ($) {
 
     if (pkg.devDependencies === undefined) {
       $devDepsList.append("<li class='empty'>None found in package.json</li>")
-      applyStyles()
     } else {
       var depNames = Object.keys(pkg.devDependencies)
 
@@ -101,7 +97,6 @@ appAPI.ready(function ($) {
           if (dep.repository && dep.repository.url) {
             $('#devDep-' + dep.name).append(" <a href='" + dep.repository.url + "'>(repo)</a>")
           }
-          applyStyles()
         })
       }
     }

--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ appAPI.ready(function ($) {
     '.deps {' +
       'list-style: none;' +
       'padding: 0 !important;' +
+      'font-size: 13px;' +
     '}' +
 
     '.deps > li {' +

--- a/index.js
+++ b/index.js
@@ -21,11 +21,11 @@ appAPI.ready(function ($) {
   var $devDepsList = $("<ol class='deps markdown-body'>");
 
   $template.clone()
-  .append('<h3>Dependencies', $depsList)
+  .append('<h3 id="dependencies">Dependencies', $depsList)
   .appendTo('.repository-content');
 
   $template.clone()
-  .append('<h3>Dev dependencies', $devDepsList)
+  .append('<h3 id="dev-dependencies">Dev dependencies', $devDepsList)
   .appendTo('.repository-content');
 
   $('<style>').appendTo('head').html(

--- a/index.js
+++ b/index.js
@@ -43,25 +43,6 @@ appAPI.ready(function ($) {
       borderBottom: 'none'
     })
 
-    $('.deps > li > span').css({
-      display: 'inline-block'
-    })
-
-    $('.deps > li > span.name').css({
-      minWidth: '500px',
-      maxWidth: '600px'
-    })
-
-    $('.deps > li > span.count').css({
-      color: '#999',
-      minWidth: '100px'
-    })
-
-    $('.deps > li > span.count em').css({
-      color: '#000',
-      fontStyle: 'normal'
-    })
-
     $('li.empty').css({
       opacity: '0.6'
     })


### PR DESCRIPTION
https://github.com/zeke/npm-hub/pull/7#issuecomment-222343707

I also made a change to simplify the style application. I would have used template literals but they're not supported in Safari 8

The 13px style matches the file list above the readme

<img width="1008" alt="screen shot 2016-06-08 at 10 11 47" src="https://cloud.githubusercontent.com/assets/1402241/15881794/a82dd2d2-2ced-11e6-9ec1-fcc3d0c491c7.png">
