### PR TITLE
Add button to launch visualization of entire module dependency tree

### DIFF
--- a/extension/index.js
+++ b/extension/index.js
@@ -1,4 +1,4 @@
-$(() => {
+$().ready(() => {
   // Are we on a repo page?
   const [, user, repo] = document.location.pathname.match(/\/+([^/]*)\/([^(/|\?)]*)/) || [];
   if (!user) return
@@ -7,7 +7,7 @@ $(() => {
   if (!$('.files [title="package.json"]').length) return
 
   // Assemble API URL for fetching raw json from github
-  const pkgUrl = 'https://raw.githubusercontent.com/' + user + '/' + repo + '/master/package.json'
+  const depUrl = 'https://registry.npmjs.org/' + name
 
   // Set up list containers and headings
   const $template = $('#readme').clone().empty().removeAttr('id');
@@ -15,7 +15,11 @@ $(() => {
   const $depsList = $("<ol class='deps markdown-body'>");
   const $devDepsList = $("<ol class='deps markdown-body'>");
 
+  const $depsVisBtn = $("<button class='btn btn-sm viz-btn' type='button'>Dependency tree visualization</button>");
+  $depsVisBtn.attr("style", "float: right; margin: 5px 5px 0 0;");
+
   $template.clone()
+  .append($depsVisBtn)
   .append('<h3 id="dependencies">Dependencies', $depsList)
   .appendTo('.repository-content');
 
@@ -24,6 +28,7 @@ $(() => {
   .appendTo('.repository-content');
 
   backgroundFetch(pkgUrl).then(pkg => {
+    $depsVisBtn.click({pkg}, viewDepsViz);
     addDependencies(pkg.dependencies, $depsList);
     addDependencies(pkg.devDependencies, $devDepsList);
   });
@@ -49,4 +54,13 @@ $(() => {
     }
   }
 
-})
+  function viewDepsViz(e) {
+    const npmPkgName = e.data.pkg.name;
+    const windowFeatures = "resizable,scrollbars,status";
+
+    var otherWindow = window.open(`http://npm.anvaka.com/#/view/2d/${npmPkgName}`, "npmanvaka", windowFeatures);
+    otherWindow.opener = null;
+    otherWindow.location = url;
+    return false;
+  }
+});

--- a/extension/index.js
+++ b/extension/index.js
@@ -7,7 +7,7 @@ $().ready(() => {
   if (!$('.files [title="package.json"]').length) return
 
   // Assemble API URL for fetching raw json from github
-  const depUrl = 'https://registry.npmjs.org/' + name
+  const pkgUrl = 'https://raw.githubusercontent.com/' + user + '/' + repo + '/master/package.json'
 
   // Set up list containers and headings
   const $template = $('#readme').clone().empty().removeAttr('id');
@@ -28,7 +28,7 @@ $().ready(() => {
   .appendTo('.repository-content');
 
   backgroundFetch(pkgUrl).then(pkg => {
-    $depsVisBtn.click({pkg}, viewDepsViz);
+    $depsVisBtn.wrap(`<a href="http://npm.anvaka.com/#/view/2d/${pkg.name}"></a>`);
     addDependencies(pkg.dependencies, $depsList);
     addDependencies(pkg.devDependencies, $devDepsList);
   });
@@ -52,15 +52,5 @@ $().ready(() => {
     } else {
       $list.append("<li class='empty'>None found in package.json</li>");
     }
-  }
-
-  function viewDepsViz(e) {
-    const npmPkgName = e.data.pkg.name;
-    const windowFeatures = "resizable,scrollbars,status";
-
-    var otherWindow = window.open(`http://npm.anvaka.com/#/view/2d/${npmPkgName}`, "npmanvaka", windowFeatures);
-    otherWindow.opener = null;
-    otherWindow.location = url;
-    return false;
   }
 });


### PR DESCRIPTION
[anvaka/npmgraph.an](https://github.com/anvaka/npmgraph.an) provides a nice visualization of the entire dep tree.

This PR adds a button into the injected DOM so you can easily click to view this tree:

![image](https://cloud.githubusercontent.com/assets/39191/18406885/81585172-76b8-11e6-85e2-03fd8f1b1866.png)
