### PR TITLE
Add support for private repos

### DIFF
--- a/extension/index.js
+++ b/extension/index.js
@@ -27,13 +27,11 @@ jQuery(() => {
   .append('<h3 id="dev-dependencies">Dev dependencies', $devDepsList)
   .appendTo('.repository-content');
 
-  fetch(pkgUrl, { credentials: 'include' }).then(res => {
-    res.text().then(domStr => {
-      const pkg = JSON.parse($(domStr).find('.blob-wrapper').text());
-      $depsVisBtn.wrap(`<a href="http://npm.anvaka.com/#/view/2d/${pkg.name}"></a>`);
-      addDependencies(pkg.dependencies, $depsList);
-      addDependencies(pkg.devDependencies, $devDepsList);
-    });
+  fetch(pkgUrl, { credentials: 'include' }).then(res => res.text()).then(domStr => {
+    const pkg = JSON.parse($(domStr).find('.blob-wrapper').text());
+    $depsVisBtn.wrap(`<a href="http://npm.anvaka.com/#/view/2d/${pkg.name}"></a>`);
+    addDependencies(pkg.dependencies, $depsList);
+    addDependencies(pkg.devDependencies, $devDepsList);
   });
 
   function addDependencies(dependencies, $list) {

--- a/extension/index.js
+++ b/extension/index.js
@@ -7,7 +7,7 @@ jQuery(() => {
   if (!$('.files [title="package.json"]').length) return
 
   // Assemble API URL for fetching raw json from github
-  const pkgUrl = 'https://raw.githubusercontent.com/' + user + '/' + repo + '/master/package.json'
+  const pkgUrl = `https://github.com/${user}/${repo}/blob/master/package.json`;
 
   // Set up list containers and headings
   const $template = $('#readme').clone().empty().removeAttr('id');
@@ -27,10 +27,13 @@ jQuery(() => {
   .append('<h3 id="dev-dependencies">Dev dependencies', $devDepsList)
   .appendTo('.repository-content');
 
-  backgroundFetch(pkgUrl).then(pkg => {
-    $depsVisBtn.wrap(`<a href="http://npm.anvaka.com/#/view/2d/${pkg.name}"></a>`);
-    addDependencies(pkg.dependencies, $depsList);
-    addDependencies(pkg.devDependencies, $devDepsList);
+  fetch(pkgUrl, { credentials: 'include' }).then(res => {
+    res.text().then(domStr => {
+      const pkg = JSON.parse($(domStr).find('.blob-wrapper').text());
+      $depsVisBtn.wrap(`<a href="http://npm.anvaka.com/#/view/2d/${pkg.name}"></a>`);
+      addDependencies(pkg.dependencies, $depsList);
+      addDependencies(pkg.devDependencies, $devDepsList);
+    });
   });
 
   function addDependencies(dependencies, $list) {


### PR DESCRIPTION
Thanks for the excellent extension @zeke and @bfred-it!

Took a stab at adding support for private repos, since I use them on a day-to-day basis. I initially was going to make a request to `https://github.com/user/repo/raw/master/package.json`, but it 301s to a host that isn't allowed by the content security policy on the page.

I needed to move the request from the background page to the content script, because the current session cookie needs to be sent with the request for auth w/ private repositories.